### PR TITLE
ENT:TranslatePaths

### DIFF
--- a/lua/entities/lvs_wheeldrive_lighthandler.lua
+++ b/lua/entities/lvs_wheeldrive_lighthandler.lua
@@ -79,6 +79,8 @@ function ENT:Initialize()
 
 	if not istable( base.Lights ) then return end
 
+	self:TranslatePaths( base, base.Lights )
+
 	self:InitializeLights( base, base.Lights )
 
 	for typeid, typedata in pairs( base.Lights ) do
@@ -99,6 +101,24 @@ function ENT:Initialize()
 		data.max = #data.pattern
 
 		self._TriggerList[ typedata.Trigger ] = data
+	end
+end
+
+function ENT:TranslatePaths( base, data )
+	if not istable( data ) then return end
+
+	local materials = base:GetMaterials()
+
+	for typeid, typedata in pairs( data ) do
+		if ( typedata.SubMaterialID or not typedata.SubMaterialPath ) then continue end
+		
+		local subMaterialID = table.KeyFromValue( materials, typedata.SubMaterialPath )
+
+		if ( subMaterialID ) then
+			subMaterialID = subMaterialID - 1
+
+			typedata.SubMaterialID = subMaterialID
+		end
 	end
 end
 


### PR DESCRIPTION
For every entry in **ENT.Lights** that holds a _SubMaterialPath_ variable instead of a _SubMaterialID_.

Look for the correct _SubMaterialID_ and assign it to the table, **if it exists**.

Example:
![image](https://github.com/user-attachments/assets/d85e99bd-481c-49c8-8951-3e3484cce257)

It's as simple as that, and it fits my workflow.

Pros:
- I can compile models 28921 times and not worry about materials switching places

Cons:
- Make them up

I didn't test a model with more than 32 materials, we can add a warning for crackheads pushing models with **1282 materials** in the source engine.