### PR TITLE
Fix NULL physics object error

### DIFF
--- a/lua/entities/lvs_wheeldrive_trackphysics.lua
+++ b/lua/entities/lvs_wheeldrive_trackphysics.lua
@@ -158,7 +158,7 @@ if SERVER then
 		base:OnTakeDamage( dmginfo )
 	end
 
-	function ENT:PhysicsCollide( data, phys )
+	function ENT:PhysicsCollide( data, physobj )
 		local HitEntity = data.HitEntity
 		local HitObject = data.HitObject
 

--- a/lua/entities/lvs_wheeldrive_wheel/init.lua
+++ b/lua/entities/lvs_wheeldrive_wheel/init.lua
@@ -107,8 +107,12 @@ function ENT:PhysicsMaterialUpdate( TargetValue )
 end
 
 function ENT:PhysicsOnGround( PhysObj )
-	if not PhysObj then
+	if not IsValid(PhysObj) then
 		PhysObj = self:GetPhysicsObject()
+	end
+
+	if not IsValid(PhysObj) then
+		return false
 	end
 
 	local EntLoad,_ = PhysObj:GetStress()


### PR DESCRIPTION
Returns false by default if a valid one can't be obtained